### PR TITLE
prevent skip on previous action

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -36,6 +36,9 @@ const onMessage = (msg, sender, sendResponse) => {
     case 'clearSkips':
       clearSkips();
       break;
+    case 'navCatched':
+      catchNav(msg.payload);
+      break;
     default:
       console.warn('Unrecognized message: ' + msg.action);
   }
@@ -85,7 +88,9 @@ const processUrl = (url) => {
  * Passes a message to the content script to skip the image
  */
 const skipImage = () => {
-  if (!storage.getSkipSetting()) {
+  let _doNotSkipNext = doNotSkipNext;
+  doNotSkipNext = false;
+  if (!storage.getSkipSetting() || _doNotSkipNext) {
     return;
   }
   chrome.tabs.query({active: true, currentWindow: true}, tabs => {
@@ -185,6 +190,20 @@ const toggleStoring = () => {
  */
 const clearSkips = () => {
   storage.setHistory({});
+}
+
+/**
+ * Called when a navigation action ( go to previous or go to next ) is catched.
+ * Set the flag doNotSkipNext depending of the action.
+ * The current strategy is to not skip if the action is previous, or if the altKey was down.
+ * @param {Object}  payload
+ * @param {String}  payload.direction
+ * @param {Boolean} payload.ctrlKey
+ * @param {Boolean} payload.altKey
+ */
+let doNotSkipNext = false;
+const catchNav = ({direction, ctrlKey, altKey}) => {
+  doNotSkipNext = direction == 'prev' || altKey;
 }
 
 init();

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -2,6 +2,7 @@
 
 import skipper from './skipper';
 import keyboard from './keyboard';
+import { storage } from '../utils';
 import {listenButtonClick, listenKeyShortcuts}  from './nav';
 
 const init = () => {
@@ -19,8 +20,11 @@ const init = () => {
  *                               the message
  */
 const onMessage = (msg, sender, sendResponse) => {
-  if (msg.action === 'skip') {
+  if (msg.action === 'skip' && !storage.getDoNotSkipNext()) {
     skipper.goToUnseen(msg.payload.history);
+  }
+  if (msg.action === 'resetDoNotSkipNextFlag') {
+    storage.setDoNotSkipNext(false);
   }
 }
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -2,10 +2,13 @@
 
 import skipper from './skipper';
 import keyboard from './keyboard';
+import {listenButtonClick, listenKeyShortcuts}  from './nav';
 
 const init = () => {
   chrome.extension.onMessage.addListener(onMessage);
   window.addEventListener('keydown', keyboard.onHotKey, false);
+  listenButtonClick();
+  listenKeyShortcuts();
 }
 
 /**

--- a/src/client/nav.js
+++ b/src/client/nav.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Tries to get the prev and next button with their classname,
+ * listens to mouseclick event and delegate to navHandler.
+ */
+const listenButtonClick = () => {
+  let nextButton = document.querySelector('.navNext')[0];
+  let prevButton = document.querySelector('.navPrev')[0];
+  if (nextButton && prevButton) {
+    nextButton.addEventListener('mouseclick', navHandler.bind(null, 'next'));
+    prevButton.addEventListener('mouseclick', navHandler.bind(null, 'prev'));
+  }
+}
+
+/**
+ * Listens to right and left arrow keys (which are shortcuts for prev and next) and delegate to navHandler.
+ */
+const listenKeyShortcuts = () => {
+  window.addEventListener('keydown', (e) => {
+    if (e.target != document.body) {
+      return;
+    }
+    switch(e.which){
+      case 37 :
+        navHandler('prev', e);
+        break;
+      case 39 :
+        navHandler('next', e);
+        break;
+    }
+  })
+}
+
+/**
+ * Called when a perv or next action is catched.
+ * Sends a 'navCatched' action to the background script.
+ * The background script should know how to interpret the action, and decide to disable the skip.
+ * @param {String}   direction
+ * @param {DOMevent} e
+ */
+const navHandler = (direction, e) => {
+  chrome.extension.sendMessage({
+    action: 'navCatched',
+    payload: {
+      direction,
+      altKey: e.altKey,
+      ctrlKey: e.ctrlKey
+    }
+  });
+}
+
+export default {
+  listenButtonClick,
+  listenKeyShortcuts
+};

--- a/src/client/nav.js
+++ b/src/client/nav.js
@@ -4,14 +4,14 @@ import { storage } from '../utils';
 
 /**
  * Tries to get the prev and next button with their classname,
- * listens to mouseclick event and delegate to navHandler.
+ * listens to mousedown event and delegate to navHandler.
  */
 const listenButtonClick = () => {
-  let nextButton = document.querySelector('.navNext')[0];
-  let prevButton = document.querySelector('.navPrev')[0];
+  let nextButton = document.querySelector('.navNext');
+  let prevButton = document.querySelector('.navPrev');
   if (nextButton && prevButton) {
-    nextButton.addEventListener('mouseclick', navHandler.bind(null, 'next'));
-    prevButton.addEventListener('mouseclick', navHandler.bind(null, 'prev'));
+    nextButton.addEventListener('mousedown', navHandler.bind(null, 'next'));
+    prevButton.addEventListener('mousedown', navHandler.bind(null, 'prev'));
   }
 }
 

--- a/src/client/nav.js
+++ b/src/client/nav.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { storage } from '../utils';
+
 /**
  * Tries to get the prev and next button with their classname,
  * listens to mouseclick event and delegate to navHandler.
@@ -34,20 +36,15 @@ const listenKeyShortcuts = () => {
 
 /**
  * Called when a perv or next action is catched.
- * Sends a 'navCatched' action to the background script.
- * The background script should know how to interpret the action, and decide to disable the skip.
+ * Set the doNotSkipNext flag up for the next image if the shift key is down.
+ * It will disable the skip.
  * @param {String}   direction
  * @param {DOMevent} e
  */
 const navHandler = (direction, e) => {
-  chrome.extension.sendMessage({
-    action: 'navCatched',
-    payload: {
-      direction,
-      altKey: e.altKey,
-      ctrlKey: e.ctrlKey
-    }
-  });
+  if (e.shiftKey) {
+    storage.setDoNotSkipNext(true);
+  }
 }
 
 export default {

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,8 +3,10 @@
 const HISTORY = 'bceef547-efd8-4409-8519-907d2ada8db6';
 const SKIPS = '3ce4c137-7fe4-4acc-a3ce-9088ee083fcd';
 const STORE = '104ff5e8-3701-4d53-a712-1c4589273e31';
+const SKIPNEXT = '233fb976-8fe1-44e7-902f-970102458810';
 export const keys = {
   HISTORY,
   SKIPS,
+  SKIPNEXT,
   STORE
 }

--- a/src/utils/storageHelpers.js
+++ b/src/utils/storageHelpers.js
@@ -70,6 +70,23 @@ const setStoreSetting = (value) => {
 }
 
 /**
+ * Gets the doNotSkip flag saved in storage
+ * @return  {Boolean} value `true` to disable the skip behavior on the next image.
+ */
+const getDoNotSkipNext = () => {
+  let skipString = localStorage.getItem(keys.SKIPNEXT);
+  return safeGetBool(skipString);
+}
+
+/**
+ * Sets the doNotSkip flag and saves it to storage
+ * @param  {Boolean} value `true` to disable the skip behavior on the next image.
+ */
+const setDoNotSkipNext = (value) => {
+  localStorage.setItem(keys.SKIPNEXT, String(value));
+}
+
+/**
  * Checks a strigified boolean and defaults to `true` if the string is `null`
  * @param  {String} stringValue The stringified bool
  * @return {Boolean}            `true` if the string is null or it represents
@@ -100,5 +117,7 @@ export default {
   getSkipSetting,
   setSkipSetting,
   getStoreSetting,
-  setStoreSetting
+  setStoreSetting,
+  setDoNotSkipNext,
+  getDoNotSkipNext
 };


### PR DESCRIPTION
Hello,

I wanted to add behavior such as not skipping when I hit the previous key.

I made a try: the next action ( shortcuts and buttons ) are catched and a message is sent to the background script, which then sets a `doNotSkipNext` flag.

Problem is, the message is received after the url change event.

I will try to figure out another way to achieve that.

I personnaly prefer this behavior, do you think it could be useful to have it as option ?
